### PR TITLE
Update ClientDomainService.cs

### DIFF
--- a/Sistem.Domain.Impl/Services/ClientDomainService.cs
+++ b/Sistem.Domain.Impl/Services/ClientDomainService.cs
@@ -25,6 +25,8 @@ namespace Sistem.Domain.Impl.Services
 
             if (_unitOfWork.ClientRepository.GetByUser(entity.User) != null)
                 throw new ArgumentException("Usuario ja existe");
+
+            entity.Id = 0;
             
             await _unitOfWork.ClientRepository.CreateAsync(entity);
         }


### PR DESCRIPTION
O problema é que a coluna no seu banco de dados é auto_increment, gerada automaticamente pelo SQLServer e o dado na entidade Client também é gerado automaticamente, isso causa conflito.
Pra resolver, força na aplicação o Id da entidade para 0, com isso ele vai considerar o Id do banco de dados e salvar corretamente.
Tem outras soluções, como o SET IDENTITY_INSERT ON, alterar a coluna removendo o auto_increment e etc.
Por enquanto usa isso